### PR TITLE
Make gem compatible with newrelic_rpm version 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ Or install it yourself as:
 
 ## License
 
-* Copyright (c) 2017 Railsware [www.railsware.com](http://www.railsware.com)
+* Copyright (c) 2019 Railsware [www.railsware.com](http://www.railsware.com)
 * [MIT](www.opensource.org/licenses/MIT)

--- a/lib/new_relic/agent/instrumentation/em_http.rb
+++ b/lib/new_relic/agent/instrumentation/em_http.rb
@@ -17,7 +17,7 @@ DependencyDetection.defer do
       def activate_connection_with_newrelic(client)
         wrapped_request = ::NewRelic::Agent::HTTPClients::EmHttpRequest.new(client)
 
-        client.newrelic_segment = ::NewRelic::Agent::Transaction.start_external_request_segment(
+        client.newrelic_segment = ::NewRelic::Agent::Tracer.start_external_request_segment(
           wrapped_request.type, wrapped_request.uri, wrapped_request.method
         )
 

--- a/newrelic_em_http.gemspec
+++ b/newrelic_em_http.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "newrelic_em_http"
-  spec.version       = "0.0.2"
+  spec.version       = "0.0.3"
   spec.authors       = ["Andriy Yanko"]
   spec.email         = ["andriy.yanko@railsware.com"]
 
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "newrelic_rpm", "> 4.0.0"
+  spec.add_dependency "newrelic_rpm", "> 6.0.0"
 
   spec.add_development_dependency "eventmachine", ">= 1.2.0"
   spec.add_development_dependency "em-http-request", ">= 1.0.0"


### PR DESCRIPTION
* Use new `Tracer` class instead of `Transaction`
* Bump minimal required version of `newrelic_rpm`
* Bump version of the gem